### PR TITLE
Update Mod_ProceduralParts.cfg

### DIFF
--- a/GameData/000_FilterExtensions_Configs/Default/Mod_ProceduralParts.cfg
+++ b/GameData/000_FilterExtensions_Configs/Default/Mod_ProceduralParts.cfg
@@ -23,5 +23,6 @@ CATEGORY:NEEDS[ProceduralParts]
 		list = 5,Aerodynamics
 		list = 6,Thermal
 		list = 7,Electrical
+		list = 8,Utility
 	}
 }


### PR DESCRIPTION
When you click on the Procedural Parts icon, neither life support tank shows up.  This is because the "Mod_ProceduralParts.cfg" config file doesn't have a "Utility" sub-category.

Proposed fix: Add a "Utility" subcategory so that the life support tanks show up.